### PR TITLE
Publish man pages to /man/

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,13 +1,33 @@
-image: archlinux
+image: alpine/edge
 oauth: pages.sr.ht/PAGES:RW
 sources:
   - https://github.com/swaywm/swaywm.org
 packages:
   - hut
+  - mandoc
+  - sway-doc
 tasks:
   - build: |
       cd swaywm.org/
       curl --fail -o site/intro.webm https://l.sr.ht/lJ9C.webm
+  - man: |
+      man2html() {
+        # $1: section
+        # $2: name
+        gunzip -c /usr/share/man/man$1/$2.$1.gz | mandoc -T html -O style=man-style.css |
+          sed -E 's,<b>(sway[a-z-]*)</b>\(([0-9])\),<a href="\1.\2.html"><b>\1</b>(\2)</a>,g' > $2.$1.html
+      }
+      cd swaywm.org/site/man/
+      man2html 1 sway
+      man2html 1 swaymsg
+      man2html 1 swaynag
+      man2html 5 sway-bar
+      man2html 5 sway-input
+      man2html 5 sway-output
+      man2html 5 sway
+      man2html 5 swaynag
+      man2html 7 sway-ipc
+      man2html 7 swaybar-protocol
   - deploy: |
       cd swaywm.org/
       [ "$(git rev-parse origin/master)" = "$(git rev-parse HEAD)" ] || complete-build

--- a/site/man/man-style.css
+++ b/site/man/man-style.css
@@ -1,0 +1,66 @@
+/* From: https://git.sr.ht/~emersion/soju/tree/website */
+
+body {
+  max-width: 88ex;
+  padding: 2ex 4ex;
+
+  font-family: monospace;
+  font-size: 14px;
+}
+
+.head,
+.foot {
+  width: 100%;
+  color: #999;
+}
+
+.foot {
+  margin-top: 3ex;
+}
+
+.head-vol {
+  text-align: center;
+}
+
+.head-rtitle {
+  text-align: right;
+}
+
+h1 {
+  font-size: 16px;
+}
+
+h2 {
+  font-size: 14px;
+}
+
+p {
+  text-align: justify;
+}
+.Bd-indent {
+  padding-left: 4ex;
+}
+
+pre {
+  color: #434241;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #18191a;
+    color: #ffffff;
+  }
+
+  .head,
+  .foot {
+    color: #cac0b3;
+  }
+
+  a {
+    color: #3daeff;
+  }
+
+  pre {
+    color: #e4ded3;
+  }
+}


### PR DESCRIPTION
We'd still need to link these in the index page.

I used the pages from the latest stable release from alpine/edge. This is a lot simpler/faster than cloning the sway repository and building the whole project.